### PR TITLE
Bugfix - DateFormat( dt, "short") wasn't returning proper date

### DIFF
--- a/src/com/naryx/tagfusion/expression/function/dateFormat.java
+++ b/src/com/naryx/tagfusion/expression/function/dateFormat.java
@@ -80,7 +80,7 @@ public class dateFormat extends functionBase {
 			// (refer to bug #1908)
 			cfmlFormatString = specifiedFormat.toLowerCase();
 			if (cfmlFormatString.equals("short")) {
-				cfmlFormatString = "m/d/y";
+				cfmlFormatString = "m/d/yy";
 			} else if (cfmlFormatString.equals("medium")) {
 				cfmlFormatString = "mmm d, yyyy";
 			} else if (cfmlFormatString.equals("long")) {

--- a/webapp/openbdtest/functions/date/ParseDateTimeTest.cfc
+++ b/webapp/openbdtest/functions/date/ParseDateTimeTest.cfc
@@ -379,7 +379,7 @@
 		</cftry>
 	</cffunction>
 
-	<cffunction name="checkDate">
+	<cffunction name="checkDate" access="private">
 		<cfargument name="parsed">
 		<cfargument name="year">
 		<cfargument name="month">


### PR DESCRIPTION
DateFormat( dt, "short") was returning full length year, I updated so it returns just two digits now, I also updated the MXUnit test helper function so MXUnit doesn't try to run it as a test (And fails)