### PR TITLE
Updating Console to output if running 127.0.0.1 or localhost (Which r…

### DIFF
--- a/src/com/naryx/tagfusion/expression/function/ext/Console.java
+++ b/src/com/naryx/tagfusion/expression/function/ext/Console.java
@@ -92,7 +92,7 @@ public class Console extends functionBase {
 
 	
 	private boolean isLocalIP( String ip ){
-		if ( ip != null && ip.equals("127.0.0.1") )
+		if ( ip != null && (ip.equals("127.0.0.1") || ip.equals("0:0:0:0:0:0:0:1")) )
 			return true;
 		else
 			return false;


### PR DESCRIPTION
Console checks if running locally or debug is set to true in bluedragon file.

Currently, 127.0.0.1 works but localhost does not, so I added support for that by also checking for the ipv6 translation of localhost (0:0:0:0:0:0:0:1)