### PR TITLE
Bugfix - Returnformat in cfscript was case sensitive

### DIFF
--- a/src/com/naryx/tagfusion/cfm/parser/script/CFFuncDeclStatement.java
+++ b/src/com/naryx/tagfusion/cfm/parser/script/CFFuncDeclStatement.java
@@ -95,7 +95,7 @@ public class CFFuncDeclStatement extends CFParsedStatement implements java.io.Se
 				throw new ParseException(_name, "The attribute " + nextKey.toUpperCase() + " must have a constant value");
 			}
 
-			attributes.put(nextKey, ((CFLiteral) nextExpr).getStringImage());
+			attributes.put(nextKey.toLowerCase(), ((CFLiteral) nextExpr).getStringImage());
 		}
 
 	}


### PR DESCRIPTION
Returnformat for function declaration in cfscript was case sensitive.

This worked
remote function awesome() returnformat="json" {}

But this didn't
remote function awesome() returnFormat="json" {}