### PR TITLE
I've added the ability to have pretty-printed json output in the console when dumping complex data types

### DIFF
--- a/src/com/naryx/tagfusion/expression/function/ext/Console.java
+++ b/src/com/naryx/tagfusion/expression/function/ext/Console.java
@@ -37,7 +37,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.naryx.tagfusion.cfm.engine.cfArrayData;
 import com.naryx.tagfusion.cfm.engine.cfBooleanData;
 import com.naryx.tagfusion.cfm.engine.cfData;
-import com.naryx.tagfusion.cfm.engine.cfEngine;
 import com.naryx.tagfusion.cfm.engine.cfQueryResultData;
 import com.naryx.tagfusion.cfm.engine.cfSession;
 import com.naryx.tagfusion.cfm.engine.cfStructData;
@@ -49,11 +48,10 @@ import com.naryx.tagfusion.expression.function.string.serializejson.CaseType;
 import com.naryx.tagfusion.expression.function.string.serializejson.DateType;
 
 public class Console extends functionBase {
-	private static final long serialVersionUID = 1L;
+	private static final long serialVersionUID 	= 1L;
 
-	protected static boolean	bConsoleOn = false;
-	protected static boolean	bPrettyConsoleOn = false;
-	protected static boolean	bFirstRun = true;
+	protected static boolean	bConsoleOn 			= false;
+	protected static boolean	bPrettyConsoleOn 	= false;
 	
 	public Console() {
 		min = 1;
@@ -69,21 +67,13 @@ public class Console extends functionBase {
 	public java.util.Map getInfo(){
 		return makeInfo(
 				"debugging", 
-				"If the console has been turned on, or the request is coming from 127.0.0.1/localhost (local), will output the variable(s) to the engine console. If you have set <prettyconsole>true</prettyconsole> under <debugoutput> in the bluedragon.xml your complex data types will be output as pretty-printed json", 
+				"If the console has been turned on, or the request is coming from 127.0.0.1/localhost (local), will output the variable(s) to the engine console.", 
 				ReturnType.BOOLEAN );
 	}
 	
 	public cfData execute(cfSession _session, List<cfData> parameters) throws cfmRunTimeException {
 		if ( bConsoleOn || isLocalIP(_session.REQ.getRemoteAddr()) ){
 			List<cfData> dataParams = parameters;
-			
-			// If this is the first time the function is run, grab the setting from bluedragon.xml
-			if (bFirstRun) {
-				bPrettyConsoleOn = cfEngine.getConfig().getBoolean( "server.debugoutput.prettyconsole" , false );
-				
-				bFirstRun = false;
-			}
-			
 			
 			// Loop all the console statements
 			ListIterator<cfData> li = dataParams.listIterator(dataParams.size());
@@ -107,6 +97,8 @@ public class Console extends functionBase {
 								// Pretty print json output if the data is a complex type
 								ObjectMapper mapper 				= new ObjectMapper();
 								StringBuilder buffer 			= new StringBuilder(5000);
+								
+								// Use the existing openbd json serializer
 								serializejson jsonserializer 	= new serializejson();
 								DateType datetype 				= DateType.LONG;
 								CaseType caseConversion 			= CaseType.MAINTAIN;

--- a/src/com/naryx/tagfusion/expression/function/ext/ConsoleOutput.java
+++ b/src/com/naryx/tagfusion/expression/function/ext/ConsoleOutput.java
@@ -29,8 +29,7 @@
 
 package com.naryx.tagfusion.expression.function.ext;
 
-import java.util.List;
-
+import com.naryx.tagfusion.cfm.engine.cfArgStructData;
 import com.naryx.tagfusion.cfm.engine.cfBooleanData;
 import com.naryx.tagfusion.cfm.engine.cfData;
 import com.naryx.tagfusion.cfm.engine.cfSession;
@@ -41,7 +40,9 @@ public class ConsoleOutput extends Console {
 	private static final long serialVersionUID = 1L;
 	
 	public ConsoleOutput() {
-		min = max = 1;
+		min = 1;
+		max = 2;
+		setNamedParams( new String[]{ "output", "pretty" } );
 	}
 
 	public String[] getParamInfo(){
@@ -53,12 +54,13 @@ public class ConsoleOutput extends Console {
 	public java.util.Map getInfo(){
 		return makeInfo(
 				"debugging", 
-				"Turns on/off the output to the console for the Console() function", 
+				"Turns on/off the output to the console and turns on/off pretty printed json output for the Console() function", 
 				ReturnType.BOOLEAN );
 	}
 	
-	public cfData execute(cfSession _session, List<cfData> parameters) throws cfmRunTimeException {
-		bConsoleOn = parameters.get(0).getBoolean();
+	public cfData execute(cfSession _session, cfArgStructData argStruct) throws cfmRunTimeException {
+		bConsoleOn = getNamedBooleanParam(argStruct, "output", false);
+		bPrettyConsoleOn = getNamedBooleanParam(argStruct, "pretty", false);
 		return cfBooleanData.TRUE;
 	}
 }


### PR DESCRIPTION
Add <prettyconsole>true</prettyconsole> under <debugoutput> and you're good to go.
Defaults to standard console output if <prettyconsole> is false or not present.

To use it, just console() things as normal, if it's a complex type and prettyprint is true, it'll parse and pretty-print the data in console.