### PR TITLE
I forgot to add the new parameter to getParamInfo for consoleOutput().

### DIFF
--- a/src/com/naryx/tagfusion/expression/function/ext/ConsoleOutput.java
+++ b/src/com/naryx/tagfusion/expression/function/ext/ConsoleOutput.java
@@ -47,7 +47,8 @@ public class ConsoleOutput extends Console {
 
 	public String[] getParamInfo(){
 		return new String[]{
-				"boolean"
+				"boolean",
+				"boolean. Defaults to false. Determines if console() should output pretty printed JSON."
 		};
 	}
 	


### PR DESCRIPTION
I forgot to add the new parameter to getParamInfo to consoleOutput(), which caused the manual page to break.