### PR TITLE
Fix log rotation nullpointer

### DIFF
--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -5,6 +5,7 @@ http://openbd.org/
 https://github.com/OpenBD/openbd-core
 __________________________________
 
+- Fix nullpointer when rotating logfiles
 - Added onexists parameter/attribute to collectioncreate()/CFCOLLECTION
 - Restored support for YES/NO in deserializejson removed in AmazonLambda function addition
 - Added allowleadingwildcard to search function and cfsearch tag

--- a/src/com/nary/util/LogFile.java
+++ b/src/com/nary/util/LogFile.java
@@ -69,6 +69,7 @@ public class LogFile extends Object implements SystemClockEvent {
 
 	private LogFile(String logPath, String _encoding, boolean _PrependTimeStamp) throws Exception {
 		filename = logPath;
+		encoding = _encoding;
 		fileWriter = new FileOutputStream(logPath,true);
 		outWriter = new OutputStreamWriter( fileWriter, _encoding );
 		logFileSize = new File( logPath ).length();


### PR DESCRIPTION
encoding was not initialized, causing a nullpointer exception on logrotation.

Once the logrotation limit is hit, the cpu and memory spikes as each log request causes a nullpointer error while failing to rotate the log.