### PR TITLE
Adding support for PATCH http verb for CFHTTP and http()

### DIFF
--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -5,6 +5,7 @@ http://openbd.org/
 https://github.com/OpenBD/openbd-core
 __________________________________
 
+- Added support for PATCH http verb to CFHTTP and http()
 - Fixed #58: NPE when serializejson ran on query result containing date pulled from Memcached
 - Fix nullpointer when rotating logfiles
 - Added onexists parameter/attribute to collectioncreate()/CFCOLLECTION

--- a/src/com/naryx/tagfusion/cfm/http/cfHttpConnection.java
+++ b/src/com/naryx/tagfusion/cfm/http/cfHttpConnection.java
@@ -60,6 +60,7 @@ import javax.net.ssl.SSLContext;
 
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
+import org.apache.http.HttpEntityEnclosingRequest;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpVersion;
@@ -624,22 +625,12 @@ public class cfHttpConnection implements cfHttpConnectionI {
 					multipartEntityBuilder.addPart( nextFile.getName(), new FileBody( nextFile.getFile(), ContentType.create( nextFile.getMimeType() ), nextFile.getFile().getName() ) );
 				}
 
-			} else if ( message instanceof HttpPut ) {
+			} else if ( message instanceof HttpPut || message instanceof HttpPatch ) {
 				fileDescriptor nextFile = files.get( 0 ); // just use the first file specified
 				try {
 					FileInputStream fileIn = new FileInputStream( nextFile.getFile() );
 					InputStreamEntity entity = new InputStreamEntity( fileIn, nextFile.getFile().length(), ContentType.create( nextFile.getMimeType() ) );
-					( ( HttpPut )message ).setEntity( entity );
-				} catch ( FileNotFoundException e ) {
-					throw newRunTimeException( "Failed to locate file " + nextFile.getFile().getAbsolutePath() );
-				}
-
-			}  else if ( message instanceof HttpPatch ) {
-				fileDescriptor nextFile = files.get( 0 ); // just use the first file specified
-				try {
-					FileInputStream fileIn = new FileInputStream( nextFile.getFile() );
-					InputStreamEntity entity = new InputStreamEntity( fileIn, nextFile.getFile().length(), ContentType.create( nextFile.getMimeType() ) );
-					( ( HttpPatch )message ).setEntity( entity );
+					( ( HttpEntityEnclosingRequest )message ).setEntity( entity );
 				} catch ( FileNotFoundException e ) {
 					throw newRunTimeException( "Failed to locate file " + nextFile.getFile().getAbsolutePath() );
 				}


### PR DESCRIPTION
The tag and script didn't support using the PATCH verb, so I added it.

Tested with

```
<cfset vars = { fields: {
	title: 'sgsfg',
	body: 'bar',
	userId: 1 } }>
							
<cfhttp url="https://httpbin.org/post" method="post">
	<cfhttpparam type="header" name="Content-Type" value="application/json" />
	<cfhttpparam type="body" value="#serializeJSON(vars)#">
</cfhttp>
<cfdump var="#deSerializeJson(cfhttp.filecontent)#">
<br>

<cfhttp url="https://httpbin.org/patch" method="patch">
	<cfhttpparam type="header" name="Content-Type" value="application/json" />
	<cfhttpparam type="body" value="#serializeJSON(vars)#">
</cfhttp>
<cfdump var="#deSerializeJson(cfhttp.filecontent)#">
<br>

<cfscript>
	data = http( url="https://httpbin.org/patch", method="patch", httpparams=[ { type: "body", value: serializeJson(vars) }, { "type" : "header", "name" : "Content-Type", "value" : "application/json" } ] );
	writedump(deSerializeJson(data.filecontent));
</cfscript>
```